### PR TITLE
Kcho/to read the keyring once

### DIFF
--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -123,17 +123,14 @@ def main():
     # run downloader once, or continuously
     if args.continuous:
         while True:
-            do(args)
+            do(args, Lochness)
             logger.info('sleeping for {0} seconds'.format(Lochness['poll_interval']))
             time.sleep(Lochness['poll_interval'])
     else:
         do(args)
 
 
-def do(args):
-    # reload config every time
-    Lochness = config.load(args.config, args.archive_base)
-
+def do(args, Lochness):
     # Lochness to Lochness transfer on the receiving side
     if args.lochness_sync_receive:
         lochness_to_lochness_transfer_receive_sftp(Lochness)

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -127,7 +127,7 @@ def main():
             logger.info('sleeping for {0} seconds'.format(Lochness['poll_interval']))
             time.sleep(Lochness['poll_interval'])
     else:
-        do(args)
+        do(args, Lochness)
 
 
 def do(args, Lochness):


### PR DESCRIPTION
The initial version of the `lochness/scripts/sync.py` loads the `Lochness` variable more than once in the flow, which requires the password to be typed more than once. If `--continuous` option is given, it requires the password continuosly. This PR updates to only load the `Lochness` when `sync.py` is executed.