### PR TITLE
RPMS module and tree.get update

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,3 +19,4 @@ paramiko = "*"
 pytz = "*"
 requests = {extras = ["security"]}
 lochness = {path = ".", editable = true}
+dpanonymize = "*"

--- a/lochness/__init__.py
+++ b/lochness/__init__.py
@@ -96,8 +96,8 @@ def initialize_metadata(Lochness, args, multiple_site_in_a_repo) -> None:
 
         elif 'rpms' in args.input_sources:
             # metadata.csv
-            id_fieldname = 'chric_subject_id'
-            consent_fieldname = 'chric_consent_date'
+            id_fieldname = Lochness['RPMS_id_colname']
+            consent_fieldname = Lochness['RPMS_consent_colname']
             RPMS.initialize_metadata(
                     Lochness, study_name, id_fieldname, consent_fieldname,
                     multiple_site_in_a_repo)

--- a/lochness/rpms/__init__.py
+++ b/lochness/rpms/__init__.py
@@ -59,8 +59,7 @@ def initialize_metadata(Lochness: 'Lochness object',
                                 str.
         multistudy: True if the rpms repo contains more than one study's data
     '''
-    study_rpms = Lochness['keyring'][f'rpms.{study_name}']
-    rpms_root_path = study_rpms['RPMS_PATH']
+    rpms_root_path = Lochness['RPMS_PATH']
 
     source_source_name_dict = {
         'beiwe': 'Beiwe', 'xnat': 'XNAT', 'dropbox': 'Drpbox',
@@ -142,8 +141,7 @@ def sync(Lochness, subject, dry=False):
     # for each subject
     subject_id = subject.id
     study_name = subject.study
-    study_rpms = Lochness['keyring'][f'rpms.{study_name}']
-    rpms_root_path = study_rpms['RPMS_PATH']
+    rpms_root_path = Lochness['RPMS_PATH']
 
     # source data
     all_df_dict = get_rpms_database(rpms_root_path)

--- a/lochness/rpms/__init__.py
+++ b/lochness/rpms/__init__.py
@@ -122,18 +122,17 @@ def initialize_metadata(Lochness: 'Lochness object',
 
 
 def get_subject_data(all_df_dict: Dict[str, pd.DataFrame],
-                     subject: object) -> Dict[str, pd.DataFrame]:
+                     subject: object,
+                     id_colname: str) -> Dict[str, pd.DataFrame]:
     '''Get subject data from the pandas dataframes in the dictionary'''
 
     subject_df_dict = {}
     for measure, measure_df in all_df_dict.items():
-        measure_df['src_subject_id'] = measure_df['src_subject_id'].astype(str)
-        subject_df = measure_df[measure_df.src_subject_id == subject.id]
+        measure_df[id_colname] = measure_df[id_colname].astype(str)
+        subject_df = measure_df[measure_df[id_colname] == subject.id]
         subject_df_dict[measure] = subject_df
 
     return subject_df_dict
-
-
 
 
 @net.retry(max_attempts=5)
@@ -148,7 +147,9 @@ def sync(Lochness, subject, dry=False):
 
     # source data
     all_df_dict = get_rpms_database(rpms_root_path)
-    subject_df_dict = get_subject_data(all_df_dict, subject)
+    subject_df_dict = get_subject_data(all_df_dict,
+                                       subject,
+                                       Lochness['RPMS_id_colname'])
 
     for measure, source_df in subject_df_dict.items():
         # target data

--- a/lochness/tree/__init__.py
+++ b/lochness/tree/__init__.py
@@ -97,7 +97,7 @@ def get(data_type, base, **kwargs):
             sub_folder = Templates[data_type]['raw'].substitute(
                     base='', **kwargs)[1:]
             sub_folder = re.sub('/(raw|processed)', '', sub_folder)
-            raw_folder = base / sub_folder / phoenix_id
+            raw_folder = base / phoenix_id / sub_folder
 
         if 'processed' in Templates[data_type]:
             # restructure root
@@ -106,7 +106,7 @@ def get(data_type, base, **kwargs):
                     base='', **kwargs)[1:]
 
             sub_folder = re.sub('/(raw|processed)', '', sub_folder)
-            processed_folder = base / sub_folder / phoenix_id
+            processed_folder = base / phoenix_id / sub_folder
 
     else:
         if 'raw' in Templates[data_type]:

--- a/scripts/lochness_create_template.py
+++ b/scripts/lochness_create_template.py
@@ -254,7 +254,8 @@ lochness_sync_history_csv: {args.lochness_sync_history_csv}
     if 'rpms' in args.sources:
         config_example += '''RPMS_PATH: /mnt/prescient/RPMS_incoming
 RPMS_id_colname: src_subject_id
-RPMS_consent_colname: Consent'''
+RPMS_consent_colname: Consent
+'''
 
     if args.s3:
         s3_lines = f'''AWS_BUCKET_NAME: ampscz-dev

--- a/scripts/lochness_create_template.py
+++ b/scripts/lochness_create_template.py
@@ -261,7 +261,7 @@ RPMS_consent_colname: Consent'''
 AWS_BUCKET_ROOT: TEST_PHOENIX_ROOT'''
         config_example += s3_lines
     
-    if args.redcap:
+    if 'redcap' in args.sources:
         config_example += '\nredcap:'
 
         for study in args.studies:

--- a/scripts/lochness_create_template.py
+++ b/scripts/lochness_create_template.py
@@ -201,14 +201,6 @@ def create_keyring_template(keyring_loc: Path, args: object) -> None:
                 "PROJECT_CID": "******",
                 }
 
-    if 'rpms' in args.sources:
-        for study in args.studies:
-            # lower part of the keyring
-            template_dict[f'rpms.{study}'] = {
-                "RPMS_PATH": "/RPMS/DAILY/EXPORT/PATH",
-                "TOKEN": "******",
-                }
-
     if args.lochness_sync_send:
         if args.s3:
             pass
@@ -258,23 +250,27 @@ sender: {args.email}
 pii_table: {args.pii_csv}
 lochness_sync_history_csv: {args.lochness_sync_history_csv}
 '''
+
+    if 'rpms' in args.sources:
+        config_example += '''RPMS_PATH:/mnt/prescient/RPMS_incoming
+RPMS_id_colname:src_subject_id
+RPMS_consent_colname:Consent'''
+
     if args.s3:
         s3_lines = f'''AWS_BUCKET_NAME: ampscz-dev
 AWS_BUCKET_ROOT: TEST_PHOENIX_ROOT'''
         config_example += s3_lines
     
-    redcap_lines = f'''
-redcap:'''
+    if args.redcap:
+        config_example += '\nredcap:'
 
-    config_example += redcap_lines
-
-    for study in args.studies:
-        redcap_deidentify_lines = f'''
+        for study in args.studies:
+            redcap_deidentify_lines = f'''
     {study}:
         deidentify: True
         data_entry_trigger_csv: {args.det_csv}
         update_metadata: True'''
-        config_example += redcap_deidentify_lines
+            config_example += redcap_deidentify_lines
 
     if 'mediaflux' in args.sources:
         config_example += '\nmediaflux:'
@@ -310,7 +306,6 @@ redcap:'''
               '''
 
             config_example += line_to_add
-
 
     if 'box' in args.sources:
         config_example += '\nbox:'
@@ -360,6 +355,7 @@ notify:
 
     with open(config_loc, 'w') as f:
         f.write(config_example)
+
 
 def create_example_meta_file_advanced(metadata: str,
                                       project_name: str,

--- a/scripts/lochness_create_template.py
+++ b/scripts/lochness_create_template.py
@@ -157,10 +157,10 @@ def create_keyring_template(keyring_loc: Path, args: object) -> None:
                 'USERNAME': f'**id_for_xnat_{study}**',
                 'PASSWORD': f'**password_for_xnat_{study}**'}
 
-    if 'box' in args.sources:
-        if 'SECRETS' not in template_dict['lochness'].keys():
-            template_dict['lochness']['SECRETS'] = {}
+    if 'SECRETS' not in template_dict['lochness'].keys():
+        template_dict['lochness']['SECRETS'] = {}
 
+    if 'box' in args.sources:
         for study in args.studies:
             template_dict['lochness']['SECRETS'][study] = 'LOCHNESS_SECRETS'
 
@@ -169,6 +169,20 @@ def create_keyring_template(keyring_loc: Path, args: object) -> None:
                 'CLIENT_ID': '**CLIENT_ID_FROM_BOX_APPS**',
                 'CLIENT_SECRET': '**CLIENT_SECRET_FROM_BOX_APPS**',
                 'API_TOEN': '**APITOKEN_FROM_BOX_APPS**'}
+
+    if 'mediaflux' in args.sources:
+        for study in args.studies:
+            template_dict['lochness']['SECRETS'][study] = 'LOCHNESS_SECRETS'
+
+            # lower part of the keyring
+            template_dict[f'mediaflux.{study}'] = {
+                'HOST': 'mediaflux.researchsoftware.unimelb.edu.au',
+                'PORT': '443',
+                'TRANSPORT': 'https',
+                'TOKEN': '**TOKEN_delete_this_line_if_no_token**',
+                'DOMAIN': 'local',
+                'USER': '**ID**',
+                'PASSWORD': '**PASSWORD**'}
 
     if 'mindlamp' in args.sources:
         for study in args.studies:
@@ -268,7 +282,7 @@ redcap:'''
         for study in args.studies:
             line_to_add = f'''
     {study}:
-        namespace: /DATA/ROOT/UNDER/MEDIAFLUX
+        namespace: /DATA/ROOT/UNDER/MEDIAFLUX/{study}
         delete_on_success: False
         file_patterns:
             actigraphy:

--- a/scripts/lochness_create_template.py
+++ b/scripts/lochness_create_template.py
@@ -252,9 +252,9 @@ lochness_sync_history_csv: {args.lochness_sync_history_csv}
 '''
 
     if 'rpms' in args.sources:
-        config_example += '''RPMS_PATH:/mnt/prescient/RPMS_incoming
-RPMS_id_colname:src_subject_id
-RPMS_consent_colname:Consent'''
+        config_example += '''RPMS_PATH: /mnt/prescient/RPMS_incoming
+RPMS_id_colname: src_subject_id
+RPMS_consent_colname: Consent'''
 
     if args.s3:
         s3_lines = f'''AWS_BUCKET_NAME: ampscz-dev

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -26,6 +26,7 @@ from lochness.transfer import lochness_to_lochness_transfer_sftp
 from lochness.transfer import lochness_to_lochness_transfer_rsync
 from lochness.transfer import lochness_to_lochness_transfer_s3
 from lochness.transfer import lochness_to_lochness_transfer_receive_sftp
+import dpanonymize
 
 SOURCES = {
     'xnat': XNAT,
@@ -157,6 +158,9 @@ def do(args, Lochness):
         else:
             for Module in args.source:
                 lochness.attempt(Module.sync, Lochness, subject, dry=args.dry)
+
+    # annonymize PII
+    dpanonymize.lock_lochness(Lochness)
 
     # transfer new files after all sync attempts are done
     if args.lochness_sync_send:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ requires = [
     'six',
     'pytz',
     'pandas',
-    'jsonpath_ng'
+    'jsonpath_ng',
+    'dpanonymize'
 ]
 
 test_requirements = [

--- a/tests/lochness_test/box/test_box.py
+++ b/tests/lochness_test/box/test_box.py
@@ -328,134 +328,134 @@ def test_box_sync_module_no_redownload(args_and_Lochness_BIDS):
     show_tree_then_delete('tmp_lochness')
 
 
-# def test_box_with_given_structure():
-    # site_subject = {
-            # 'PronetLA': ['LA123456',
-                         # 'LA132457',
-                         # 'LA124358'],
-            # 'PronetSL': ['SL124352',
-                         # 'SL123453',
-                         # 'SL124539'],
-            # 'PronetWU': ['WU142358',
-                         # 'WU124351',
-                         # 'WU142531']
-            # }
+def test_box_with_given_structure():
+    site_subject = {
+            'PronetLA': ['LA12345',
+                         'LA13245',
+                         'LA12435'],
+            'PronetSL': ['SL12431',
+                         'SL12348',
+                         'SL12453'],
+            'PronetWU': ['WU14235',
+                         'WU12438',
+                         'WU14253']
+            }
 
-    # modalities = {
-            # 'actigraphy': ['actigraphy'],
-            # 'interviews': ['onsiteinterview', 'offsiteinterview'],
-            # 'eeg': ['eeg']
-            # }
+    modalities = {
+            'actigraphy': ['actigraphy'],
+            'interviews': ['onsiteinterview', 'offsiteinterview'],
+            'eeg': ['eeg']
+            }
 
-    # # 'phone': ['accel', 'audioRecordings', 'gps', 'power', 'surveyAnswers', 'surveyTimings']
+    # 'phone': ['accel', 'audioRecordings', 'gps', 'power', 'surveyAnswers', 'surveyTimings']
 
 
-    # root = Path('example_box_root')
-    # try:
-        # shutil.rmtree(root)
-    # except:
-        # pass
+    root = Path('example_box_root')
+    try:
+        shutil.rmtree(root)
+    except:
+        pass
 
-    # for site, subjects in site_subject.items():
+    for site, subjects in site_subject.items():
 
-        # site_dir = root / site
-        # for modality, subdirectories in modalities.items():
-            # modality_dir = site_dir / modality
-            # for subject in subjects:
-                # subject_dir = modality_dir / subject
+        site_dir = root / site
+        for modality, subdirectories in modalities.items():
+            modality_dir = site_dir / modality
+            for subject in subjects:
+                subject_dir = modality_dir / subject
 
-                # for file in subdirectories:
-                    # if modality == 'phone':
-                        # final_dir = modality_dir / file / subject
-                        # final_dir.mkdir(parents=True, exist_ok=True)
+                for file in subdirectories:
+                    if modality == 'phone':
+                        final_dir = modality_dir / file / subject
+                        final_dir.mkdir(parents=True, exist_ok=True)
 
-                        # if file.endswith('interview') or file.endswith('cordings'):
-                            # suffix = 'mp4'
-                        # else:
-                            # suffix = 'csv'
+                        if file.endswith('interview') or file.endswith('cordings'):
+                            suffix = 'mp4'
+                        else:
+                            suffix = 'csv'
                             
-                        # file_name = f"{subject}_{file}.{suffix}"
+                        file_name = f"{subject}_{file}.{suffix}"
 
-                        # with open(final_dir / file_name, 'w') as f:
-                            # f.write('')
-                    # else:
-                        # final_dir = subject_dir
-                        # final_dir.mkdir(parents=True, exist_ok=True)
+                        with open(final_dir / file_name, 'w') as f:
+                            f.write('')
+                    else:
+                        final_dir = subject_dir
+                        final_dir.mkdir(parents=True, exist_ok=True)
 
-                        # if file.endswith('interview') or file.endswith('cordings'):
-                            # suffix = 'mp4'
-                        # else:
-                            # suffix = 'csv'
+                        if file.endswith('interview') or file.endswith('cordings'):
+                            suffix = 'mp4'
+                        else:
+                            suffix = 'csv'
                             
-                        # file_name = f"{subject}_{file}.{suffix}"
+                        file_name = f"{subject}_{file}.{suffix}"
 
-                        # with open(final_dir / file_name, 'w') as f:
-                            # f.write('')
+                        with open(final_dir / file_name, 'w') as f:
+                            f.write('')
 
-    # # show_tree_then_delete('example_box_root')
-
-
-
-# def test_mediaflux_with_given_structure():
-    # site_subject = {
-            # 'PrescientME': ['ME123456',
-                            # 'ME132457',
-                            # 'ME124358'],
-            # 'PrescientAD': ['AD124352',
-                            # 'AD123453',
-                            # 'AD124539'],
-            # 'PrescientPE': ['PE142358',
-                            # 'PE124351',
-                            # 'PE142531']
-            # }
-
-    # modalities = {
-            # 'actigraphy': ['actigraphy'],
-            # 'interviews': ['onsiteinterview', 'offsiteinterview'],
-            # 'eeg': ['eeg']
-            # }
-
-    # # 'phone': ['accel', 'audioRecordings', 'gps', 'power', 'surveyAnswers', 'surveyTimings']
+    # show_tree_then_delete('example_box_root')
 
 
-    # root = Path('example_mediaflux_root')
-    # try:
-        # shutil.rmtree(root)
-    # except:
-        # pass
 
-    # for site, subjects in site_subject.items():
+def test_mediaflux_with_given_structure():
+    site_subject = {
+            'PrescientME': ['ME12345',
+                            'ME13245',
+                            'ME12435'],
+            'PrescientAD': ['AD12430',
+                            'AD12349',
+                            'AD12453'],
+            'PrescientPE': ['PE14235',
+                            'PE12437',
+                            'PE14253']
+            }
 
-        # site_dir = root / site
-        # for modality, subdirectories in modalities.items():
-            # modality_dir = site_dir / modality
-            # for subject in subjects:
-                # subject_dir = modality_dir / subject
+    modalities = {
+            'actigraphy': ['actigraphy'],
+            'interviews': ['onsiteinterview', 'offsiteinterview'],
+            'eeg': ['eeg']
+            }
 
-                # for file in subdirectories:
-                    # if modality == 'phone':
-                        # final_dir = modality_dir / file / subject
-                        # final_dir.mkdir(parents=True, exist_ok=True)
+    # 'phone': ['accel', 'audioRecordings', 'gps', 'power', 'surveyAnswers', 'surveyTimings']
 
-                        # if file.endswith('interview') or file.endswith('cordings'):
-                            # suffix = 'mp4'
-                        # else:
-                            # suffix = 'csv'
+
+    root = Path('example_mediaflux_root')
+    try:
+        shutil.rmtree(root)
+    except:
+        pass
+
+    for site, subjects in site_subject.items():
+
+        site_dir = root / site
+        for modality, subdirectories in modalities.items():
+            modality_dir = site_dir / modality
+            for subject in subjects:
+                subject_dir = modality_dir / subject
+
+                for file in subdirectories:
+                    if modality == 'phone':
+                        final_dir = modality_dir / file / subject
+                        final_dir.mkdir(parents=True, exist_ok=True)
+
+                        if file.endswith('interview') or file.endswith('cordings'):
+                            suffix = 'mp4'
+                        else:
+                            suffix = 'csv'
                             
-                        # file_name = f"{subject}_{file}.{suffix}"
+                        file_name = f"{subject}_{file}.{suffix}"
 
-                        # with open(final_dir / file_name, 'w') as f:
-                            # f.write('')
-                    # else:
-                        # final_dir = subject_dir
-                        # final_dir.mkdir(parents=True, exist_ok=True)
+                        with open(final_dir / file_name, 'w') as f:
+                            f.write('')
+                    else:
+                        final_dir = subject_dir
+                        final_dir.mkdir(parents=True, exist_ok=True)
 
-                        # if file.endswith('interview') or file.endswith('cordings'):
-                            # suffix = 'mp4'
-                        # else:
-                            # suffix = 'csv'
+                        if file.endswith('interview') or file.endswith('cordings'):
+                            suffix = 'mp4'
+                        else:
+                            suffix = 'csv'
                             
-                        # file_name = f"{subject}_{file}.{suffix}"
+                        file_name = f"{subject}_{file}.{suffix}"
 
-                        # with open(final_dir / file_name, 'w') as f:
-                            # f.write('')
+                        with open(final_dir / file_name, 'w') as f:
+                            f.write('')

--- a/tests/lochness_test/rpms/test_rpms.py
+++ b/tests/lochness_test/rpms/test_rpms.py
@@ -147,15 +147,15 @@ def test_get_rpms_database():
 def test_get_rpms_real_example(args):
     outdir = 'tmp_lochness'
     args.outdir = outdir
+    args.sources = ['RPMS']
     create_lochness_template(args)
-    KeyringAndEncryptRPMS(args.outdir)
     create_fake_rpms_repo()
-    rpms_root_path = '/mnt/prescient/RPMS_incoming'
+    KeyringAndEncrypt(Path(outdir))
 
     dry=False
     study_name = 'StudyA'
     Lochness = config_load_test(f'{args.outdir}/config.yml', '')
-    Lochness['keyring']['rpms.StudyA']['RPMS_PATH'] = '/mnt/prescient/RPMS_incoming'
+    # Lochness['keyring']['rpms.StudyA']['RPMS_PATH'] = '/mnt/prescient/RPMS_incoming'
 
     initialize_metadata(Lochness, study_name, 'src_subject_id', 'Consent', False)
 

--- a/tests/lochness_test/rpms/test_rpms.py
+++ b/tests/lochness_test/rpms/test_rpms.py
@@ -69,7 +69,7 @@ def test_initializing_based_on_rpms(Lochness):
         - ...
     '''
     create_fake_rpms_repo()
-    Lochness['keyring']['rpms.StudyA'] = {'RPMS_PATH': Path('RPMS_repo').absolute()}
+    Lochness['RPMS_PATH'] = Path('RPMS_repo').absolute()
     initialize_metadata(Lochness, 'StudyA', 'record_id1', 'Consent', False)
     df = pd.read_csv('tmp_lochness/PHOENIX/GENERAL/StudyA/StudyA_metadata.csv')
     print(df)
@@ -81,7 +81,7 @@ def test_create_lochness_template(Lochness):
     create_fake_rpms_repo()
     # create_lochness_template(args)
     study_name = 'StudyA'
-    Lochness['keyring']['rpms.StudyA'] = {'RPMS_PATH': Path('RPMS_repo').absolute()}
+    Lochness['RPMS_PATH'] = Path('RPMS_repo').absolute()
     initialize_metadata(Lochness, study_name, 'record_id1', 'Consent', False)
 
     for subject in lochness.read_phoenix_metadata(Lochness,
@@ -116,14 +116,17 @@ class KeyringAndEncryptRPMS(KeyringAndEncrypt):
 def test_sync_from_empty(args):
     outdir = 'tmp_lochness'
     args.outdir = outdir
+    args.sources = ['RPMS']
     create_lochness_template(args)
-    KeyringAndEncryptRPMS(args.outdir)
+    KeyringAndEncrypt(args.outdir)
     create_fake_rpms_repo()
 
     dry=False
     study_name = 'StudyA'
     Lochness = config_load_test(f'{args.outdir}/config.yml', '')
-    initialize_metadata(Lochness, study_name, 'record_id1', 'Consent', False)
+    print(Lochness)
+    initialize_metadata(Lochness, study_name, Lochness['RPMS_id_colname'],
+            'Consent', False)
 
     for subject in lochness.read_phoenix_metadata(Lochness,
                                                   studies=['StudyA']):
@@ -155,7 +158,6 @@ def test_get_rpms_real_example(args):
     dry=False
     study_name = 'StudyA'
     Lochness = config_load_test(f'{args.outdir}/config.yml', '')
-    # Lochness['keyring']['rpms.StudyA']['RPMS_PATH'] = '/mnt/prescient/RPMS_incoming'
 
     initialize_metadata(Lochness, study_name, 'src_subject_id', 'Consent', False)
 
@@ -164,5 +166,31 @@ def test_get_rpms_real_example(args):
         sync(Lochness, subject, dry)
 
     # print the structure
-    # show_tree_then_delete('tmp_lochness')
+    show_tree_then_delete('tmp_lochness')
 
+def test_get_rpms_real_example_sync(args):
+    outdir = 'tmp_lochness'
+    args.outdir = outdir
+    args.s3 = True
+    args.sources = ['RPMS']
+    args.BIDS = True
+    create_lochness_template(args)
+    create_fake_rpms_repo()
+    KeyringAndEncrypt(Path(outdir))
+
+    dry=False
+    study_name = 'StudyA'
+    Lochness = config_load_test(f'{args.outdir}/config.yml', '')
+    print(Lochness)
+    print(Lochness['BIDS'])
+    print(Lochness['BIDS'])
+    print(Lochness['BIDS'])
+    # # Lochness['keyring']['rpms.StudyA']['RPMS_PATH'] = '/mnt/prescient/RPMS_incoming'
+
+    initialize_metadata(
+            Lochness, study_name, 
+            Lochness['RPMS_id_colname'], 'Consent', False)
+
+    for subject in lochness.read_phoenix_metadata(
+            Lochness, studies=['StudyA']):
+        sync(Lochness, subject, dry)


### PR DESCRIPTION
## Updates following tests of RPMS module in the Prescient server, with the test RPMS DB examples shared by Larry.

### Changes in tree.get (this is the major change in this PR)
- While testing lochness with dpanonymize for `RPMS` in Prescient server, I've noticed my mistake in the `tree.get` function.
- `study / raw / datatype / subject` -> fixed to -> `study / raw / subject / data`


### Changes in RPMS module
- `RPMS` path to be loaded from `config.yml` rather than the keyring file.
- Prescient team is providing a table that has a different naming convention from that of Pronet. I've updated to included the name of subject ID column in the table to be loaded from the `config.yml`.

### Testing modules for RPMS
- [x] RPMS module working with the example RPMS outputs in the Prescient server.
- [x] RPMS module + dpanonymize pushing data to s3

