### PR TITLE
Remove unused **kwargs from Templates.substitute()

### DIFF
--- a/lochness/tree/__init__.py
+++ b/lochness/tree/__init__.py
@@ -94,28 +94,24 @@ def get(data_type, base, **kwargs):
         if 'raw' in Templates[data_type]:
             # restructure root
             base = Path(base).parent.parent / study / 'raw'
-            sub_folder = Templates[data_type]['raw'].substitute(
-                    base='', **kwargs)[1:]
+            sub_folder = Templates[data_type]['raw'].substitute(base='')[1:]
             sub_folder = re.sub('/(raw|processed)', '', sub_folder)
             raw_folder = base / phoenix_id / sub_folder
 
         if 'processed' in Templates[data_type]:
             # restructure root
             base = Path(base).parent.parent / study / 'processed'
-            sub_folder = Templates[data_type]['processed'].substitute(
-                    base='', **kwargs)[1:]
+            sub_folder = Templates[data_type]['processed'].substitute(base='')[1:]
 
             sub_folder = re.sub('/(raw|processed)', '', sub_folder)
             processed_folder = base / phoenix_id / sub_folder
 
     else:
         if 'raw' in Templates[data_type]:
-            raw_folder = Templates[data_type]['raw'].substitute(
-                    base=base, **kwargs)
+            raw_folder = Templates[data_type]['raw'].substitute(base=base)
 
         if 'processed' in Templates[data_type]:
-            processed_folder = Templates[data_type]['processed'].substitute(
-                    base=base, **kwargs)
+            processed_folder = Templates[data_type]['processed'].substitute(base=base)
 
     if kwargs.get('processed', True):
         if kwargs.get('makedirs', True) and \


### PR DESCRIPTION
Hi @kcho , based on @justintbaker 's comments, I did not touch any of the templates. But I have removed usused argument `**kwargs`. I did track its use in the past though:

https://github.com/harvard-nrg/lochness/blob/26fae812d761b45348c3c5992b08a36d3ad2d127/lochness/tree/__init__.py#L25-L28

and 

https://github.com/harvard-nrg/lochness/blob/26fae812d761b45348c3c5992b08a36d3ad2d127/lochness/beiwe/__init__.py#L44-L45

Accepting this pull request would be your call. I propose it so that the next reviewer can have an easier time going through `tree.get()`.

Closes #62 