### PR TITLE
Kcho/upenn redcap

### DIFF
--- a/lochness/redcap/__init__.py
+++ b/lochness/redcap/__init__.py
@@ -333,12 +333,23 @@ def sync(Lochness, subject, dry=False):
             logger.debug("Downloading REDCap data")
             _debug_tup = (redcap_instance, redcap_project, redcap_subject)
 
-            record_query = {
-                'token': api_key,
-                'content': 'record',
-                'format': 'json',
-                'records': redcap_subject
-            }
+            if 'UPENN' in redcap_instance:
+                # UPENN REDCap is set up with its own record_id, but have added
+                # "session_subid" field to note AMP-SCZ ID
+                record_query = {
+                    'token': api_key,
+                    'content': 'record',
+                    'format': 'json',
+                    'filterLogic': f"[session_subid] = '{redcap_subject}'"
+                }
+
+            else:
+                record_query = {
+                    'token': api_key,
+                    'content': 'record',
+                    'format': 'json',
+                    'records': redcap_subject
+                }
 
             if deidentify:
                 # get fields that aren't identifiable and narrow record query

--- a/lochness/redcap/__init__.py
+++ b/lochness/redcap/__init__.py
@@ -336,11 +336,13 @@ def sync(Lochness, subject, dry=False):
             if 'UPENN' in redcap_instance:
                 # UPENN REDCap is set up with its own record_id, but have added
                 # "session_subid" field to note AMP-SCZ ID
+                redcap_subject_sl = redcap_subject.lower()
                 record_query = {
                     'token': api_key,
                     'content': 'record',
                     'format': 'json',
-                    'filterLogic': f"[session_subid] = '{redcap_subject}'"
+                    'filterLogic': f"[session_subid] = '{redcap_subject}' or "
+                                   f"[session_subid] = '{redcap_subject_sl}'"
                 }
 
             else:


### PR DESCRIPTION
UPENN neuropsych REDCap source has been set up in a way to use "session_subid" to have the AMP-SCZ ID. (Note that this REDCap is for neuropsychological tests only, which is different from the general REDCap that we are using for AMP-SCZ project)

This PR is tested on Pronet data aggregation server, and fully working.