### PR TITLE
feat: to only include one dicom file name for each subject in the email

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+paramiko>=2.7.2
+pandas>=1.3.2
+boxsdk>=2.11.0
+requests>=2.26.0
+pytest>=6.2.4
+yaxil@git+https://github.com/AMP-SCZ/yaxil@main#egg=yaxil
+six>=1.16.0
+numpy>=1.20.3
+Jinja2>=2.11.3
+mano>=0.5.1
+cryptease>=0.2.0
+pytz>=2021.1
+jsonpath_ng>=1.5.2
+LAMP>=0.0.1
+PyYAML>=6.0

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ with open("README.md", "r") as fh:
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+requirements= open('requirements.txt').read().split()
+
 about = dict()
 with open(os.path.join(here, 'lochness', '__version__.py'), 'r') as f:
     exec(f.read(), about)
@@ -29,21 +31,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     python_requires='>=3.7',
-    install_requires=['yaxil>=0.5.2',
-                      'paramiko>=2.7.2',
-                      'boxsdk>=2.11.0',
-                      'jsonpath_ng>=1.5.2',
-                      'cryptease>=0.2.0',
-                      'pytz>=2021.1',
-                      'requests>=2.26.0',
-                      'six>=1.16.0',
-                      'pandas>=1.3.2',
-                      'pytest>=6.2.4',
-                      'numpy>=1.20.3',
-                      'mano>=0.5.1',
-                      'LAMP>=0.0.1',
-                      'PyYAML>=6.0',
-                      'Jinja2>=2.11.3'],
+    install_requires=requirements,
     scripts=['scripts/listen_to_redcap.py',
              'scripts/lochness_create_template.py',
              'scripts/phoenix_generator.py',


### PR DESCRIPTION
The email becomes very laggy when all the dicom file names are included. This PR updates the second part of the table in the email, to only include one dicom file name for each subject.