### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ mano>=0.5.1
 cryptease>=0.2.0
 pytz>=2021.1
 jsonpath_ng>=1.5.2
-LAMP-core
+LAMP-core>=2021.10.4
 PyYAML>=6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ mano>=0.5.1
 cryptease>=0.2.0
 pytz>=2021.1
 jsonpath_ng>=1.5.2
-LAMP>=0.0.1
+LAMP-core
 PyYAML>=6.0


### PR DESCRIPTION
LAMP should be LAMP-core


@tashrifbillah I do not see a clear version number for this module. Can you help me finding the `>=VERSION` after LAMP-core please?
(https://github.com/BIDMCDigitalPsychiatry/LAMP-py/tags)