### PR TITLE
feat: email summary to use mailx

### DIFF
--- a/lochness/email/__init__.py
+++ b/lochness/email/__init__.py
@@ -29,27 +29,26 @@ def send(recipients, sender, subject, message):
     s.quit()
 
 
-def send_detail_google(Lochness,
-                       title: str, subtitle: str, first_message: str,
-                       second_message: str, code: List[str],
-                       in_mail_footer: str,
-                       test: bool = False) -> None:
-    '''Send email using a Gmail account with "Less secure app access" turned on
-
-    Set up a Google account to send out emails using Google's SMTP server. You need
-    to turn on "Less secure app access" from "Manage your Google account" page 
-    in order to use this feature.
+def send_detail(Lochness,
+                title: str, subtitle: str, first_message: str,
+                second_message: str, code: List[str],
+                in_mail_footer: str,
+                test: bool = False,
+                mailx: bool = True) -> None:
+    '''Send detailed email
 
     The configuration file should have
-
         sender: senderemail@gmail.com
         notify:
           __global__:
               - receiver1@anyemail.com
               - receiver2@anyemail.com
 
-    The keyring file should have email password at the same level as the
-    "SECRETS" field.
+    When mailx = False, send_detail function will assume you are using Google
+    smpt to send out the emails. For this case, you will need to set up a
+    Google account with "Less secure app access" turned on, from "Manage
+    your Google account" page. Also, the keyring file should have email
+    password at the same level as the "SECRETS" field.
 
         {...,
         "SECRETS": {"PronetLA": "LOCHNESS_SECRETS"},
@@ -58,7 +57,6 @@ def send_detail_google(Lochness,
     '''
 
     sender = Lochness['sender']
-    sender_pw = Lochness['keyring']['lochness']['email_sender_pw']
     recipients_for_each_study = Lochness['notify']
 
     recipients = []
@@ -90,11 +88,17 @@ def send_detail_google(Lochness,
     msg['Subject'] = f'Lochness update {datetime.now(tz).date()}'
     msg['From'] = sender
     msg['To'] = recipients[0]
-    s = smtplib.SMTP('smtp.gmail.com', 587)
-    s.ehlo()
-    s.starttls()
-    s.ehlo()
-    s.login(sender, sender_pw)
+
+    if mailx:
+        s = smtplib.SMTP('localhost')
+    else:
+        sender_pw = Lochness['keyring']['lochness']['email_sender_pw']
+        s = smtplib.SMTP('smtp.gmail.com', 587)
+        s.ehlo()
+        s.starttls()
+        s.ehlo()
+        s.login(sender, sender_pw)
+
     if not test:
         s.sendmail(sender, recipients, msg.as_string())
         print('Email sent')
@@ -104,7 +108,8 @@ def send_detail_google(Lochness,
     s.quit()
 
 
-def send_out_daily_updates(Lochness, days: int = 1, test: bool = False):
+def send_out_daily_updates(Lochness, days: int = 1,
+                           test: bool = False, mailx: bool = True):
     '''Send daily updates from Lochness'''
 
     s3_log = Path(Lochness['phoenix_root']) / 's3_log.csv'
@@ -144,13 +149,13 @@ def send_out_daily_updates(Lochness, days: int = 1, test: bool = False):
     day_days = 'days' if days > 1 else 'day'
 
     if len(s3_df_selected) == 0:
-        send_detail_google(
+        send_detail(
             Lochness,
             'Lochness', f'Daily updates {datetime.now(tz).date()}',
             'There is no update!', '',
             list_of_lines_from_tree,
             '',
-            test)
+            test, mailx)
     else:
         s3_df_selected.columns = ['Transfer time (UTC)', 'File name',
                                   'Protected', 'Study', 'Processed', 'Subject',
@@ -173,7 +178,7 @@ def send_out_daily_updates(Lochness, days: int = 1, test: bool = False):
 
         in_mail_footer = 'Note that only S3 transferred files are included.'
 
-        send_detail_google(
+        send_detail(
             Lochness,
             'Lochness', f'Daily updates {datetime.now(tz).date()} '
                         f'(for the past {days} {day_days})',
@@ -181,7 +186,7 @@ def send_out_daily_updates(Lochness, days: int = 1, test: bool = False):
             'Each file in detail' + s3_df_selected.to_html(),
             list_of_lines_from_tree,
             in_mail_footer,
-            test)
+            test, mailx)
 
 
 def attempts_error(Lochness, attempt):

--- a/tests/lochness_test/email/test_email.py
+++ b/tests/lochness_test/email/test_email.py
@@ -43,4 +43,14 @@ def test_box_sync_module_no_redownload(args_and_Lochness_BIDS):
 
     Lochness['notify']['test'] = ['sky8671@gmail.com']
     # send_out_daily_updates(Lochness, test=True)
+    send_out_daily_updates(Lochness, mailx=False)
+
+
+def test_box_sync_module_mailx(args_and_Lochness_BIDS):
+    args, Lochness = args_and_Lochness_BIDS
+    Lochness['sender'] = 'hahah@ho.ho'
+
+    Lochness['notify']['test'] = ['sky8671@gmail.com']
     send_out_daily_updates(Lochness)
+
+


### PR DESCRIPTION
Pronet has added `mailx` to the dev and production server. Switching to `mailx` email summary by default instead of gmail SMTP.