### PR TITLE
Kcho/pronet mindlamp test

### DIFF
--- a/lochness/redcap/__init__.py
+++ b/lochness/redcap/__init__.py
@@ -146,8 +146,7 @@ def initialize_metadata(Lochness: 'Lochness object',
                 subject_dict[source_name] = \
                         f"{source}.{study_name}:{source_id}"
             else:
-                subject_dict[source_name] = \
-                        f"{source}.{study_name}:{source_id}"
+                pass
 
         df_tmp = pd.DataFrame.from_dict(subject_dict, orient='index')
         df = pd.concat([df, df_tmp.T])
@@ -247,7 +246,7 @@ def get_run_sheets_for_datatypes(json_path: Union[Path, str]) -> None:
 def check_if_modified(subject_id: str,
                       existing_json: str,
                       df: pd.DataFrame) -> bool:
-    '''check if subject data has been modified in the data entry trigger db
+    '''Check if subject data has been modified in the data entry trigger db
 
     Comparing unix times of the json modification and lastest redcap update
     '''
@@ -327,8 +326,8 @@ def sync(Lochness, subject, dry=False):
                     pass  # if modified, carry on
                 else:
                     logger.debug(f"{subject.study}/{subject.id} "
-                                 "No updates - not downloading REDCap data")
-                    break  # if not modified break
+                                 "No DET updates")
+                    # break  # if not modified break
 
             logger.debug("Downloading REDCap data")
             _debug_tup = (redcap_instance, redcap_project, redcap_subject)

--- a/tests/lochness_test/mindlamp/test_mindlamp.py
+++ b/tests/lochness_test/mindlamp/test_mindlamp.py
@@ -460,3 +460,30 @@ def test_sync_skip_for_the_day_ip(args):
     Lochness = config_load_test(syncArgs.config)
     for subject in lochness.read_phoenix_metadata(Lochness, syncArgs.studies):
         sync(Lochness, subject, False)
+
+
+def test_pronet_mindlamp(args):
+    args.studies = ['StudyA']
+    syncArgs = SyncArgs(args.outdir)
+    syncArgs.studies = ['StudyA']
+    sources = ['mindlamp']
+    syncArgs.update_source(sources)
+
+    create_lochness_template(args)
+    syncArgs.config = args.outdir / 'config.yml'
+    # _ = KeyringAndEncryptMindlampAdminIP(args.outdir)
+    _ = KeyringAndEncryptMindlamp(args.outdir)
+    # _ = KeyringAndEncryptMindlampYoon(args.outdir)
+
+    phoenix_root = args.outdir / 'PHOENIX'
+    information_to_add_to_metadata = {'mindlamp': [
+        {'subject_id': '1001', 'source_id': 'U2763080389'},
+        {'subject_id': '1002', 'source_id': 'U4361826716'}
+        ]}
+    
+    initialize_metadata_test(phoenix_root, 'StudyA',
+                             information_to_add_to_metadata)
+    Lochness = config_load_test(syncArgs.config)
+    for subject in lochness.read_phoenix_metadata(Lochness, syncArgs.studies):
+        sync(Lochness, subject, False)
+


### PR DESCRIPTION
PR about a few changes that I made in the Pronet data aggregation server

1. Temporarily bypassing `Data Entry Trigger` break logic. 
The Pronet REDCap server still does not have the `data entry trigger` ready and we do not know when it would be available yet. In order to keep testing the dataflow, I'm escaping the `break`, to download all REDCap data, whenever we run `sync.py`. We shall work on the `DET` once Pronet has the functionality to do so.

2. Minor edits in the `initialize_metadata()`
To pass any AMP-SCZ REDCap subject record that does not have mindlamp ID, from populating the `mindlamp` part in the `metadata.csv` file.

