### PR TITLE
fix: when metadata row does not have mindlamp ID

### DIFF
--- a/lochness/__init__.py
+++ b/lochness/__init__.py
@@ -305,6 +305,8 @@ def _parse_redcap(value, default_id=None):
 def _parse_mindlamp(value, default_id=None):
     '''helper function to parse a mindlamp metadata value'''
     default = 'mindlamp.*:{ID}'.format(ID=default_id)
+    if value == 'nan':
+        return col.defaultdict(list)
     return _simple_parser(value, default=default)
 
 

--- a/lochness/utils/path_checker.py
+++ b/lochness/utils/path_checker.py
@@ -3,10 +3,13 @@ import re
 from pathlib import Path
 from typing import List
 
-def ampscz_id_validate(some_id):
+def ampscz_id_validate(some_id: str):
     # https://github.com/AMP-SCZ/subject-id-validator
     # Basic checks: len == 7, first two chars are not numbers,
     # all other chars are numbers
+    if type(some_id) != str:
+        return False
+
     if len(some_id) != 7:
         return False
 

--- a/lochness/utils/path_checker.py
+++ b/lochness/utils/path_checker.py
@@ -3,6 +3,38 @@ import re
 from pathlib import Path
 from typing import List
 
+def ampscz_id_validate(some_id):
+    # https://github.com/AMP-SCZ/subject-id-validator
+    # Basic checks: len == 7, first two chars are not numbers,
+    # all other chars are numbers
+    if len(some_id) != 7:
+        return False
+
+    if not (some_id[0].isalpha() and some_id[1].isalpha()):
+        return False
+
+    if not all([n.isdecimal() for n in some_id[2:6]]):
+        return False
+
+    # Convert ID to array of numbers, excluding check digit
+    id_array = []
+    id_array.append(ord(some_id[0].upper()))
+    id_array.append(ord(some_id[1].upper()))
+    id_array = id_array + list(some_id[2:6])
+
+    # Use check digit algorithm to generate correct check digit
+    check_digit_array = []
+
+    for pos in range(len(id_array)):
+        check_digit_array.append(int(id_array[pos]) * (pos+1))
+    check_digit = sum(check_digit_array) % 10
+
+    # Check correct check digit against entered ID
+    if int(some_id[6]) != check_digit:
+        return False
+
+    return True
+
 
 def nth_item_from_path(df: pd.DataFrame, n: int) -> pd.Series:
     '''Return n th item from pd.Series of paths'''
@@ -46,9 +78,7 @@ def update_interviews_check(df: pd.DataFrame) -> pd.DataFrame:
     # subject location is different
     int_df = df.loc[int_index]
     int_df['subject'] = nth_item_from_path(int_df, 3)
-    int_df['subject_check'] = int_df['subject'].str.match(
-            '[A-Z]{2}\d{5}').fillna(False)
-
+    int_df['subject_check'] = int_df['subject'].apply(ampscz_id_validate)
     df.loc[int_index] = int_df
 
 
@@ -61,7 +91,7 @@ def update_interviews_transcript_check(df: pd.DataFrame) -> pd.DataFrame:
     transcript_int_df = df.loc[transcript_int_index]
     transcript_int_df['subject'] = nth_item_from_path(transcript_int_df, 4)
     transcript_int_df['subject_check'] = transcript_int_df['subject'
-            ].str.match('[A-Z]{2}\d{5}').fillna(False)
+            ].apply(ampscz_id_validate)
 
     # check site and AMPSCZ IDs in the transcript file name
     for index, row in transcript_int_df.iterrows():
@@ -69,6 +99,7 @@ def update_interviews_transcript_check(df: pd.DataFrame) -> pd.DataFrame:
             transcript_int_df.loc[index, 'subject'] = re.search(
                 r'[A-Z]{2}\d{5}', row['subject']).group(0)
             row['subject'] = transcript_int_df.loc[index, 'subject']
+            row['subject_check'] = ampscz_id_validate(row['subject'])
 
         subject = row['subject']
         site = row['site']
@@ -166,8 +197,9 @@ def check_file_path_df(df: pd.DataFrame,
 
     # main check logics start here
     df['site_check'] = df.site.str.match('Prescient|Pronet')
-    df['subject_check'] = df['subject'].str.match(
-            '[A-Z]{2}\d{5}').fillna(False)
+
+    #  validate AMPSCZ ID
+    df['subject_check'] = df['subject'].apply(ampscz_id_validate)
 
     df['modality_check'] = df['modality'].str.contains(
             'MRI|EEG|Actigraphy|Interviews').fillna(False)

--- a/lochness/utils/source_check.py
+++ b/lochness/utils/source_check.py
@@ -268,7 +268,7 @@ def get_subject_list_from_metadata(Lochness: 'lochness') -> List[str]:
     return subject_id_list
 
 
-def check_source(Lochness: 'lochness') -> None:
+def check_source(Lochness: 'lochness', test: bool = False) -> None:
     '''Check if there is any file that deviates from SOP'''
 
     subject_id_list = get_subject_list_from_metadata(Lochness)
@@ -289,7 +289,13 @@ def check_source(Lochness: 'lochness') -> None:
 
         # box
         print('Loading data list from BOX')
-        box_files_df = collect_box_files_info(keyring)
+        tmp_box_db = Path(Lochness['phoenix_root']) / \
+                '.tmp_box_source_files.csv'
+        if test:
+            box_files_df = pd.read_csv(tmp_box_db)
+        else:
+            box_files_df = collect_box_files_info(keyring)
+            box_files_df.to_csv(tmp_box_db)
 
         with tf.NamedTemporaryFile(delete=True) as f:
             box_files_df.to_csv(f.name, index=False)

--- a/scripts/send_email_update.py
+++ b/scripts/send_email_update.py
@@ -78,7 +78,7 @@ def send_email_update(config_file: str, days: int, recreate_db: bool,
         create_s3_transfer_table(Lochness)
 
     send_out_daily_updates(Lochness, days, test)
-    check_source(Lochness)
+    check_source(Lochness, test)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Lochness has been raising error when `mindlamp ID` was missing for a subject, when any of the other subjects for the same study had the mindlamp ID in the metadata.csv. 

9bab13325c10a65766a4f716445b3f9649f43846 updated to return empty `dict`, when the ID is missing, rather than causing the `_simple_parse` to return error.

(I'm not sure why already reviewed commits are appearing in the updated commits...)
