### PR TITLE
feat: exception when admin forces file permission

### DIFF
--- a/lochness/__init__.py
+++ b/lochness/__init__.py
@@ -575,7 +575,12 @@ def atomic_write(filename, content, overwrite=True, permissions=0o0644, encoding
             tmp.write(content)
         tmp.flush()
         os.fsync(tmp.fileno())
-    os.chmod(tmp.name, permissions)
+
+    try:  #
+        os.chmod(tmp.name, permissions)
+    except PermissionError:  # when admin forces output file permissions
+        pass
+
     os.rename(tmp.name, filename)
 
 

--- a/lochness/redcap/__init__.py
+++ b/lochness/redcap/__init__.py
@@ -215,7 +215,8 @@ def get_run_sheets_for_datatypes(json_path: Union[Path, str]) -> None:
                                'actigraphy': 'chrax_',
                                'mri': 'chrmri_',
                                'phone': 'chrdig_',
-                               'survey': 'chrpenn_'}
+                               'surveys': 'chrpenn_',
+                               'interviews': 'chrnsipr_'}
     for modality, fieldname in modality_fieldname_dict.items():
         modality_df = pd.DataFrame()
         raw_modality_path = raw_path / modality
@@ -241,7 +242,7 @@ def get_run_sheets_for_datatypes(json_path: Union[Path, str]) -> None:
             raw_modality_path.mkdir(exist_ok=True, parents=True)
             output_name = Path(json_path).name.split('.json')[0]
 
-            if modality == 'survey':
+            if modality == 'surveys':
                 modality_df.to_csv(raw_modality_path /
                                    f'{output_name}.Run_sheet_PennCNB.csv')
             else:


### PR DESCRIPTION
A server could be set up to force output permission of the file created under a certain mount, eg) `PHOENIX` under this mount, then can raise issue when the `atomic_write` tries to change the permission of file being written. This is the issue in the pronet production server, so `except PermissionError:` has been added.

It is a short PR, but quite an important one.