### PR TITLE
Run sheets update

### DIFF
--- a/lochness/__init__.py
+++ b/lochness/__init__.py
@@ -553,7 +553,8 @@ def iso8601(tz="UTC"):
     return dt.datetime.now(pytz.timezone(tz)).isoformat()
 
 
-def atomic_write(filename, content, overwrite=True, permissions=0o0644, encoding='utf-8'):
+def atomic_write(filename, content, overwrite=True,
+                 permissions=0o0644, encoding='utf-8'):
     '''
     Write a file atomically by writing the file content to a
     temporary location first, then renaming the file. 

--- a/lochness/redcap/__init__.py
+++ b/lochness/redcap/__init__.py
@@ -238,6 +238,10 @@ def get_run_sheets_for_datatypes(api_url, api_key,
 
             content_dict_list = json.loads(content)
 
+            # select the right form, and ignore the weird empty dictionary
+            content_dict_list = [x for x in content_dict_list if
+                    x[run_sheet_name+'_complete'] != '']
+
             # for run sheet at each timepoint - baseline, follow up1, etc.
             # content_num is set to start with 1 to match the session number
             for content_num, content_dict in enumerate(content_dict_list, 1):
@@ -638,7 +642,6 @@ if __name__ == '__main__':
     print(api_url, api_key)
 
     id_field = Lochness['redcap_id_colname']
-            # Path(Lochness['phoenix_root']) / 'PROTECTED').glob('*/raw/*'):
     for subject_path in (
             Path(Lochness['phoenix_root']) / 'PROTECTED').glob('*/raw/*'):
         subject = subject_path.name

--- a/lochness/redcap/__init__.py
+++ b/lochness/redcap/__init__.py
@@ -242,7 +242,9 @@ def get_run_sheets_for_datatypes(api_url, api_key,
             # content_num is set to start with 1 to match the session number
             for content_num, content_dict in enumerate(content_dict_list, 1):
                 content_df = pd.DataFrame.from_dict(content_dict,
-                                                    orient='index')
+                                                    orient='index',
+                                                    columns=['field_value'])
+                content_df.index.name = 'field_name'
 
                 # if all is empty, or 0
                 all_empty = ((content_df[content_df.columns[0]]=='0') |

--- a/lochness/utils/path_checker.py
+++ b/lochness/utils/path_checker.py
@@ -96,6 +96,12 @@ def update_interviews_transcript_check(df: pd.DataFrame) -> pd.DataFrame:
     transcript_int_df['subject_check'] = transcript_int_df['subject'
             ].apply(ampscz_id_validate)
 
+    # make sure there is no duplicated subject directory
+    fourth_item_in_path = nth_item_from_path(transcript_int_df, 4)  # dirname
+    fifth_item_in_path = nth_item_from_path(transcript_int_df, 5)  # file name
+    transcript_int_df['modality_check'] = \
+            fourth_item_in_path != fifth_item_in_path
+
     # check site and AMPSCZ IDs in the transcript file name
     for index, row in transcript_int_df.iterrows():
         if not row['subject_check']:


### PR DESCRIPTION
There is more than one run sheet for modalities that have more than one acquisition point. Each run sheet will be saved in a separate file, with the suffix `1`, `2`, etc.

Now run sheet csv will also have headers `field_name`, `field_value`.

