### PR TITLE
Updates from Prescients

### DIFF
--- a/lochness/__init__.py
+++ b/lochness/__init__.py
@@ -166,7 +166,8 @@ def _subjects(Lochness, study, general_folder, protected_folder, metadata_file):
         phoenix_id = row['Subject ID'].strip()
 
         # these columns are optional
-        phoenix_study = row.get('Study', study).strip()
+        # phoenix_study = row.get('Study', study).strip()
+        phoenix_study = study
 
         saliva = dict()
         if 'Saliva' in row:

--- a/lochness/__init__.py
+++ b/lochness/__init__.py
@@ -166,7 +166,6 @@ def _subjects(Lochness, study, general_folder, protected_folder, metadata_file):
         phoenix_id = row['Subject ID'].strip()
 
         # these columns are optional
-        # phoenix_study = row.get('Study', study).strip()
         phoenix_study = study
 
         saliva = dict()

--- a/lochness/keyring/__init__.py
+++ b/lochness/keyring/__init__.py
@@ -21,7 +21,6 @@ def load_encrypted_keyring(enc_keyring_loc: str) -> dict:
 
 def passphrase(Lochness, study):
     '''get passphrase for study from keyring'''
-
     if study not in Lochness['keyring']['lochness']['SECRETS']:
         raise KeyringError('lochness.SECRETS.{0} not found'.format(study))
     return Lochness['keyring']['lochness']['SECRETS'][study]

--- a/lochness/mediaflux/__init__.py
+++ b/lochness/mediaflux/__init__.py
@@ -162,6 +162,7 @@ def sync_module(Lochness: 'lochness.config',
                             # ENH set different permissions
                             # GENERAL: 0o755, PROTECTED: 0700
                             os.makedirs(mf_local, exist_ok=True)
+                            os.chmod(mf_local, 0o0770)
 
                             # subprocess call unimelb-mf-download
                             cmd = (' ').join(['unimelb-mf-download',
@@ -172,8 +173,8 @@ def sync_module(Lochness: 'lochness.config',
 
                             p = Popen(cmd, shell=True,
                                       stdout=DEVNULL, stderr=STDOUT)
-                            p.wait()
 
+                            p.wait()
                             # verify checksum after download completes if
                             # checksum does not match, data will be downloaded
                             # again ENH should we verify checksum 5 times?
@@ -181,6 +182,16 @@ def sync_module(Lochness: 'lochness.config',
                             p = Popen(cmd, shell=True,
                                       stdout=DEVNULL, stderr=STDOUT)
                             p.wait()
+
+                            # for A/V related files, force permission to 770
+                            # so A/V pipeline can work
+                            if 'interviews' in str(mf_local):
+                                for root, dirs, files in os.walk(mf_local):
+                                    for file in files:
+                                        file_p = Path(root) / file
+                                        perm = oct(file_p.stat().st_mode)[-3:]
+                                        if perm != '770':
+                                            os.chmod(file_p, 0o0770)
 
 
 def sync(Lochness, subject, dry):

--- a/lochness/rpms/__init__.py
+++ b/lochness/rpms/__init__.py
@@ -193,7 +193,8 @@ def initialize_metadata(Lochness: 'Lochness object',
             if rpms_consent_colname in df_measure:
                 subject_dict['Consent'] = df_measure[rpms_consent_colname]
             else:
-                subject_dict['Consent'] = '1988-09-16'  # pseudo-random date
+                subject_dict['Consent'] = '2021-10-01'  # pseudo-random date
+                # continue  ## subject without consent date will be ignored
 
             # mediaflux source has its foldername as its subject ID
             subject_dict['RPMS'] = f'rpms.{study_name}:' + \

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -74,7 +74,9 @@ def main():
     parser.add_argument('--continuous', action='store_true',
                         help='Continuously download data')
     parser.add_argument('--studies', nargs='+', default=[],
-                        help='Study to sync')
+                        help='Studies to sync')
+    parser.add_argument('--subject', nargs='+', default=[],
+                        help='Subjects to sync')
     parser.add_argument('--fork', action='store_true',
                         help='Daemonize the process')
     parser.add_argument('--until', type=scheduler.parse,
@@ -215,6 +217,10 @@ def do(args, Lochness):
                                      multiple_site, upenn_redcap)
 
     for subject in lochness.read_phoenix_metadata(Lochness, args.studies):
+        if args.subject:
+            if subject.id not in args.subject:
+                continue
+
         if not subject.active and args.skip_inactive:
             logger.info(f'skipping inactive subject={subject.id}, '
                         f'study={subject.study}')
@@ -235,7 +241,7 @@ def do(args, Lochness):
     #            s3_selective_sync = Lochness['s3_selective_sync'])
     #else:
     #    dpanonymize.lock_lochness(
-    #            Lochness, pii_table_loc=Lochness['pii_table'])
+    #            Lochnesss, pii_table_loc=Lochness['pii_table'])
 
     # transfer new files after all sync attempts are done
     if args.lochness_sync_send:


### PR DESCRIPTION
Updates from Prescient network server
- ignore subjects without consent date in the RPMS forms
- force A/V related files to have `770` permission for A/V pipeline
- source check function for mediaflux to include RPMS consent date