### PR TITLE
Lochness update to accommodate the new Penn CNB REDCap structure

### DIFF
--- a/lochness/redcap/__init__.py
+++ b/lochness/redcap/__init__.py
@@ -680,17 +680,17 @@ def sync(Lochness, subject, dry=False):
 
             if 'UPENN' in redcap_instance:
                 # UPENN REDCap is set up with its own record_id, but have added
-                # "session_subid" field to note AMP-SCZ ID
+                # "src_subject_id" field to note AMP-SCZ ID
                 redcap_subject_sl = redcap_subject.lower()
                 digits = [1, 2, 3, 4, 5, 6, 7, 8, 9]
                 digits_str = [str(x) for x in digits]
                 contains_logic = []
                 for subject_id in [redcap_subject, redcap_subject_sl]:
                     contains_logic += [
-                            f"contains([session_subid], '{subject_id}_{x}')"
+                            f"contains([src_subject_id], '{subject_id}_{x}')"
                             for x in digits_str]
                     contains_logic += [
-                            f"contains([session_subid], '{subject_id}={x}')"
+                            f"contains([src_subject_id], '{subject_id}={x}')"
                             for x in digits_str]
 
 
@@ -698,8 +698,8 @@ def sync(Lochness, subject, dry=False):
                     'token': api_key,
                     'content': 'record',
                     'format': 'json',
-                    'filterLogic': f"[session_subid] = '{redcap_subject}' or "
-                                   f"[session_subid] = '{redcap_subject_sl}' or "
+                    'filterLogic': f"[src_subject_id] = '{redcap_subject}' or "
+                                   f"[src_subject_id] = '{redcap_subject_sl}' or "
                                    f"{' or '.join(contains_logic)}"
                 }
 
@@ -742,9 +742,6 @@ def sync(Lochness, subject, dry=False):
                                 content_dict.pop(field['field_name'])
                             except:
                                 pass
-                                # print("lochness did not pull " \
-                                      # f"{field['field_name']}, which is a " \
-                                      # "deidentified field")
 
             content = json.dumps(content_dict_list).encode('utf-8')
 
@@ -760,7 +757,7 @@ def sync(Lochness, subject, dry=False):
                                                  dst)
                     # process_and_copy_db(Lochness, subject, dst, proc_dst)
                     # update_study_metadata(subject, json.loads(content))
-                    
+
                 else:
                     # responses are not stored atomically in redcap
                     crc_src = lochness.crc32(content.decode('utf-8'))

--- a/tests/lochness_test/redcap/test_new_upenn_redcap.py
+++ b/tests/lochness_test/redcap/test_new_upenn_redcap.py
@@ -1,0 +1,56 @@
+import lochness
+import json
+from pathlib import Path
+import sys
+lochness_root = Path(lochness.__path__[0]).parent
+scripts_dir = lochness_root / 'scripts'
+test_dir = lochness_root / 'tests'
+sys.path.append(str(scripts_dir))
+sys.path.append(str(test_dir))
+from test_lochness import Tokens
+from lochness.redcap import post_to_redcap
+
+
+def test_import():
+    print(lochness.__file__)
+
+
+def test_new_format():
+
+    token = Tokens()
+    api_key, api_url = token.read_token_or_get_input('redcap_fake')
+
+    redcap_subject = 'YA01508'
+    redcap_subject_sl = 'ya01508'
+
+    digits = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    digits_str = [str(x) for x in digits]
+    contains_logic = []
+    for subject_id in [redcap_subject, redcap_subject_sl]:
+        contains_logic += [
+                f"contains([src_subject_id], '{subject_id}_{x}')"
+                for x in digits_str]
+        contains_logic += [
+                f"contains([src_subject_id], '{subject_id}={x}')"
+                for x in digits_str]
+
+    record_query = {
+        'token': api_key,
+        'content': 'record',
+        'format': 'json',
+        'filterLogic': f"[src_subject_id] = '{redcap_subject}' or "
+                       f"[src_subject_id] = '{redcap_subject_sl}' or "
+                       f"{' or '.join(contains_logic)}"
+    }
+
+    # post query to redcap
+    content = post_to_redcap(api_url,
+                             record_query,
+                             False)
+
+    # check if response body is nothing but a sad empty array
+    content_dict_list = json.loads(content)
+    # print(content_dict_list)
+
+    content = json.dumps(content_dict_list).encode('utf-8')
+    print(content)

--- a/tests/test_lochness.py
+++ b/tests/test_lochness.py
@@ -162,6 +162,7 @@ class KeyringAndEncrypt():
         token = Tokens()
         api_token, url = token.read_token_or_get_input('redcap_fake')
 
+        self.keyring[f'redcap.{study}'] = {}
         self.keyring[f'redcap.{study}']['URL'] = url
         self.keyring[f'redcap.{study}']['API_TOKEN'] = {study: api_token}
 


### PR DESCRIPTION
The main change in the new Penn CNB REDCap is the new field name that contains AMP-SCZ IDs. (`src_subject_id`, which was `session_subid` in the previous CNB REDCap) This PR updates the field name.

Note that this PR will change the structure of UPENN JSON files, thus all downstream pipelines depending on the previous json structure need to be updated. An example of the new JSON file is located on ERIS:

> /data/predict1/home/kcho/tmp/upenn_new_format/test_one_subject.json

(Deploying this PR will make the lochness instance to overwrite all existing UPENN JSON files.)