### PR TITLE
Wait for RPMS dump at different times according to AEST/AEDT

### DIFF
--- a/lochness/rpms/__init__.py
+++ b/lochness/rpms/__init__.py
@@ -25,15 +25,18 @@ logger = logging.getLogger(__name__)
 
 def _wait():
     
+    # RPMS dumps data at 20:00 (AEDT) or at 19:00 (AEST)
+    RPMS_DUMP_HOUR=os.getenv('RPMS_DUMP_HOUR',20)
+
     # calculate _sleep in minutes
     # it is between 15 (7:55 pm) and 0 (8:10 pm)
     _sleep=0
     now=datetime.now()
-    if now.hour==19:
+    if now.hour==RPMS_DUMP_HOUR-1:
         if now.minute>=55:
             _sleep=15-(now.minute-55)
 
-    elif now.hour==20:
+    elif now.hour==RPMS_DUMP_HOUR:
         if now.minute<=10:
             _sleep=10-now.minute
 

--- a/lochness/rpms/__init__.py
+++ b/lochness/rpms/__init__.py
@@ -26,7 +26,8 @@ logger = logging.getLogger(__name__)
 def _wait():
     
     # RPMS dumps data at 20:00 (AEDT) or at 19:00 (AEST)
-    RPMS_DUMP_HOUR=os.getenv('RPMS_DUMP_HOUR',20)
+    tz=os.getenv('TIME_ZONE','AEDT')
+    RPMS_DUMP_HOUR=20 if tz=='AEDT' else 19
 
     # calculate _sleep in minutes
     # it is between 15 (7:55 pm) and 0 (8:10 pm)


### PR DESCRIPTION
Prescient Linux system appropriately updates system time.

<details><summary>Local time</summary>

```
      Local time: Sun 2023-09-10 03:40:00 AEST
  Universal time: Sat 2023-09-09 17:40:00 UTC
        RTC time: Sun 2023-09-10 03:40:00
       Time zone: Australia/Sydney (AEST, +1000)
     NTP enabled: yes
NTP synchronized: yes
 RTC in local TZ: yes
      DST active: no
 Last DST change: DST ended at
                  Sun 2023-04-02 02:59:59 AEDT
                  Sun 2023-04-02 02:00:00 AEST
 Next DST change: DST begins (the clock jumps one hour forward) at
                  Sun 2023-10-01 01:59:59 AEST
                  Sun 2023-10-01 03:00:00 AEDT
```

</details>

I think it is the RPMS dump system at RPMS end that does not update according to daylight time. As a result, with time changes, data are dumped an hour away. On the other hand, Tashrif's modifications must run right after dump so REDCap-NDA compatible data can propagate through the system. Hence, moving forward, we shall wait at different times for the dump to complete. The way Tashrif has set it up now, human intervention will not be needed.

Disclosure: Tashrif has set up `TIME_ZONE` variable in `/etc/profile.d/timezone.sh` .