### PR TITLE
fix: update AV QC requirements

### DIFF
--- a/lochness/utils/path_checker.py
+++ b/lochness/utils/path_checker.py
@@ -235,6 +235,32 @@ def update_by_removing_unused_files(df: pd.DataFrame) -> None:
     ds_store_index = df[df.file_name == '.DS_Store'].index
     df.drop(ds_store_index, inplace=True)
 
+    # recording.conf files
+    recording_conf_index = df[df.file_name == 'recording.conf'].index
+    df.drop(recording_conf_index, inplace=True)
+
+    # chat.txt files
+    chat_txt_index = df[df.file_name == 'chat.txt'].index
+    df.drop(chat_txt_index, inplace=True)
+
+
+def update_skipped_av_files(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Update the 'file_check' column in the DataFrame based on the 'parent_dir' column.
+
+    Args:
+        df (pd.DataFrame): The DataFrame containing the data.
+
+    Returns:
+        pd.DataFrame: The updated DataFrame.
+    """
+    for idx, row in df.iterrows():
+        if row["parent_dir"] == ("Extraneous files"):
+            df.loc[idx, "file_check"] = True
+        elif row["parent_dir"] == ("Additional interview files"):
+            df.loc[idx, "file_check"] = True
+    return df
+
 
 def update_by_removing_genetics_and_fluids(df: pd.DataFrame) -> None:
     '''Remove files under GeneticsAndFluids directory'''
@@ -288,13 +314,14 @@ def check_file_path_df(df: pd.DataFrame,
     update_interviews_check(df)
     update_interviews_transcript_check(df)
     update_interviews_teams_data_check(df)
+    update_skipped_av_files(df)
     update_interviews_video_check(df)
     update_interviews_audio_check(df)
 
     # ignore genetics and fluids
     update_by_removing_genetics_and_fluids(df)
 
-    # ignore .DS_Store files
+    # ignore .DS_Store, recording.conf, chat.txt
     update_by_removing_unused_files(df)
 
     # check if the subject exist in metadata

--- a/lochness/utils/path_checker.py
+++ b/lochness/utils/path_checker.py
@@ -255,9 +255,9 @@ def update_skipped_av_files(df: pd.DataFrame) -> pd.DataFrame:
         pd.DataFrame: The updated DataFrame.
     """
     for idx, row in df.iterrows():
-        if row["parent_dir"] == ("Extraneous files"):
+        if "Extraneous files" in row["parent_dir"]:
             df.loc[idx, "file_check"] = True
-        elif row["parent_dir"] == ("Additional interview files"):
+        elif "Additional interview files" in row["parent_dir"]:
             df.loc[idx, "file_check"] = True
     return df
 


### PR DESCRIPTION
From: Beau-Luke Colton

> ## Updates
> 
> 1. Please don’t flag the folder ‘Extraneous files’ 
> Along with anything inside these folders.
> FYI - This has been agreed upon by the Speech team to contain files that we want to keep, but are not audio files. These folders are only manually created by the Speech team, after review, to house these extraneous files. 
>  
> 2. Please don’t flag the folder ‘Additional interview files’ 
> Along with anything inside these folders.
> As above, this has been agreed upon by the Speech team to contain additional AV files that we want to keep, but we are not able to analyse at this time. These folders are only manually created by the Speech team, after review, to house these extra AV files. 
>  
> 3. Please don’t flag “recording.conf” files 
> The ProNET Speech team advised these files are not flagged as Out of SOP for them, please remove from ours. 
>  
> 4. Please don’t flag “chat.txt” files 
> Not necessary to flag.


This PR addresses these new requirements
