### PR TITLE
feat.: Use pexpect to provide XNAT credentials 

### DIFF
--- a/lochness/xnat/__init__.py
+++ b/lochness/xnat/__init__.py
@@ -183,7 +183,12 @@ def download_xnat_session_dataorc(
         None
     """
 
-    dataorc_binary_path = Path('/opt/software/dataorc-bin/dataorc')
+    dataorc_binary_path = shutil.which('dataorc')
+    if dataorc_binary_path is None:
+        logger.error('dataorc binary not in PATH')
+        raise Exception('dataorc binary not in PATH')
+    else:
+        dataorc_binary_path = Path(dataorc_binary_path)
 
     def clear_stored_credentials(dataorc_bindary_path: Path):
         cli = f"{dataorc_bindary_path} reset-credentials"

--- a/lochness/xnat/__init__.py
+++ b/lochness/xnat/__init__.py
@@ -4,7 +4,7 @@ import pexpect
 import yaml
 import uuid
 import xnat
-import yaxil
+# import yaxil
 import shutil
 import logging
 import lochness
@@ -225,7 +225,10 @@ def sync_xnatpy(Lochness, subject, dry=False):
         os.remove(tmp_file)
 
     for tmp_file in Path(tmp_dir).glob('tmp_xnat*'):
-        os.remove(tmp_file)
+        try:
+            os.rmdir(tmp_file)
+        except OSError as e:
+            logger.warning(f'Failed to remove {tmp_file}: {e}')
 
     for alias, xnat_uids in iter(subject.xnat.items()):
         keyring = Lochness['keyring'][alias]


### PR DESCRIPTION
`dataorc` previously relied on cached credentials. This PR makes this behavior deterministic by clearing `dataorc`'s stored credentials before each run and providing the credentials for each download using `pexpect`.

Other minor changes:
- Clear directories instead on temp files
  - `dataorc` requires a temp directory not a file, so clearing them before each run