### PR TITLE
feat: add 'shorten' option to send_out_daily_updates

### DIFF
--- a/tests/lochness_test/email/test_email.py
+++ b/tests/lochness_test/email/test_email.py
@@ -5,6 +5,7 @@ from lochness import config
 from pathlib import Path
 
 import sys
+from lochness.config import load
 lochness_root = Path(lochness.__path__[0]).parent
 scripts_dir = lochness_root / 'scripts'
 test_dir = lochness_root / 'tests'
@@ -54,3 +55,10 @@ def test_box_sync_module_mailx(args_and_Lochness_BIDS):
     send_out_daily_updates(Lochness)
 
 
+def test_email_size():
+    config_loc = '/mnt/prescient/Prescient_production/config.yml'
+    Lochness = load(config_loc)
+    Lochness['sender'] = 'kevincho@bwh.harvard.edu'
+
+    Lochness['notify']['test'] = ['kevincho@bwh.harvard.edu']
+    send_out_daily_updates(Lochness)


### PR DESCRIPTION
This PR adds an extra option to `send_out_daily_updates` to reduce the size of the daily summary email. `Summary of the files transferred to NDA` table at the top of the email now counts number of uploaded files for each site, not for each subject. And tables under `More details for each data type` now show number of subjects with same file type uploaded to NDA staging area.